### PR TITLE
Fix overflow error in initialise_load_address() bug

### DIFF
--- a/src/minidbg.cpp
+++ b/src/minidbg.cpp
@@ -146,7 +146,7 @@ void debugger::initialise_load_address() {
       std::string addr;
       std::getline(map, addr, '-');
 
-      m_load_address = std::stoi(addr, 0, 16);
+      m_load_address = std::stol(addr, 0, 16);
    }
 }
 


### PR DESCRIPTION
in debugger::initialise_load_address() in minidgb.cpp, need to change std::stoi(addr, 0, 16) to std::stol(addr, 0, 16), beacause std::stoi may cause data overflow that could result in an exception being thrown.